### PR TITLE
27 bug password recovery

### DIFF
--- a/fulabra_app/templates/fulabra_app/login.html
+++ b/fulabra_app/templates/fulabra_app/login.html
@@ -15,7 +15,10 @@
 
           <div class="card-footer bg-light border-0 py-3 text-center">
             <p class="mb-0 small text-muted fw-medium">
-              Don't have an account?
+              <a href="{% url 'password_reset' %}" class="text-decoration-none text-primary fw-semibold ms-1">Forget Password?</a>
+            </p>
+            <p class="mb-0 small text-muted fw-medium">
+              Don't have an account?  
               <a href="{% url 'register' %}" class="text-decoration-none text-primary fw-semibold ms-1">Register here</a>
             </p>
           </div>


### PR DESCRIPTION
## What does this PR solve?
This PR fixes the **[Bug] Missing button to recovery password** bug described in issue #27.

Previously, the login page did not provide a way for users to access the password recovery flow, making it difficult for users who forgot their credentials to reset their password.

*Relates to **Password Recovery** feature (#14).*

## What was implemented?
- **Interface:** Added and anchor to "Forget Password?" text.

## Acceptance Criteria Checklist
- [x] The login page displays a clear **Forgot Password?** link.
- [x] The link correctly redirects users to the password recovery page.

Closes #27