### PR TITLE
Update lobby.html

### DIFF
--- a/fulabra_app/templates/fulabra_app/lobby.html
+++ b/fulabra_app/templates/fulabra_app/lobby.html
@@ -8,8 +8,7 @@
     <div id="error-message"></div>
     <div id="players-frame" class="position-fixed top-0 end-0" style="z-index: 1050; min-width: 200px;"></div>
     <div id="title-div"></div>
-    
-    
+
     <div id="ws-connection" hx-ext="ws" ws-connect="/ws/lobby/{{ context.current_lobby.code }}/">
       <div class="container-fluid d-flex align-items-center justify-content-center bg-white text-black p-4">
         <div class="row w-100 max-width-xl justify-content-center g-4">
@@ -53,7 +52,7 @@
             </div>
           </div>
 
-          {% if context.player.user and context.current_lobby.leader == context.user %}
+          {% if context.player.user and context.current_lobby.leader == user.player %}
             {% include 'fulabra_app/partials/online_friends_list.html' %}
           {% endif %}
         </div>


### PR DESCRIPTION
## What does this PR solve?
This PR fixes the **[Bug] Online Friends Container Rendering** bug described in issue #46.

Previously, the **"Online Friends"** container was not displayed for the lobby host due to an incorrect template comparison.

## What was done?
- Updated the conditional check in `lobby.html`.
- Fixed the comparison to use the logged-in player's instance (`user.player`) instead of the authenticated user object, ensuring the host is correctly identified.

## Acceptance Criteria
- [x] The "Online Friends" container is rendered correctly when the logged-in user is the lobby host.

Closes #46