### PR TITLE
Refactor notificaitons to strategy

### DIFF
--- a/fulabra_app/services/notification_strategy.py
+++ b/fulabra_app/services/notification_strategy.py
@@ -9,7 +9,6 @@ from ..utils import hx_redirect
 
 
 class NotificationStrategy(ABC):
-    """Interface: cada tipo de notificação implementa seu próprio accept/reject."""
     @abstractmethod
     def handle(self, request, notification, action):
         pass
@@ -49,8 +48,22 @@ class GameInviteStrategy(NotificationStrategy):
             )
         return None
 
-
-NOTIFICATION_STRATEGIES = {
+_STRATEGIES = {
     "friend_request": FriendRequestStrategy(),
     "game_invite": GameInviteStrategy(),
 }
+
+class NotificationContext:
+    def __init__(self, notification):
+        self.notification = notification
+        self.strategy = _STRATEGIES.get(notification.notification_type)
+
+    def execute(self, request, action) -> HttpResponse | None:
+        if not self.strategy:
+            return None
+
+        if not self.notification.is_read:
+            self.notification.is_read = True
+            self.notification.save()
+
+        return self.strategy.handle(request, self.notification, action)

--- a/fulabra_app/services/notification_strategy.py
+++ b/fulabra_app/services/notification_strategy.py
@@ -1,0 +1,56 @@
+from abc import ABC, abstractmethod
+
+from django.http import HttpResponse
+from channels.layers import get_channel_layer
+from asgiref.sync import async_to_sync
+
+from ..models import FriendRequest, LobbyGroup
+from ..utils import hx_redirect
+
+
+class NotificationStrategy(ABC):
+    """Interface: cada tipo de notificação implementa seu próprio accept/reject."""
+    @abstractmethod
+    def handle(self, request, notification, action):
+        pass
+
+
+class FriendRequestStrategy(NotificationStrategy):
+    def handle(self, request, notification, action):
+        friend_request = FriendRequest.objects.filter(id=notification.target_id).first()
+        if friend_request:
+            if action == "accept":
+                friend_request.status = "accepted"
+                request.user.friends.add(friend_request.from_user)
+                friend_request.from_user.friends.add(request.user)
+
+            elif action == "reject":
+                friend_request.status = "rejected"
+
+            friend_request.save()
+        return None
+
+
+class GameInviteStrategy(NotificationStrategy):
+    def handle(self, request, notification, action):
+        if action == "accept":
+            lobby = LobbyGroup.objects.filter(id=notification.target_id).first()
+
+            if lobby:
+                return hx_redirect("lobby_invite", kwargs={"lobby_code": lobby.code})
+            return HttpResponse("Lobby no longer exists", status=404)
+
+        elif action == "reject":
+            # Se o convite foi recusado, libera o botão de volta pra enviar convite
+            channel_layer = get_channel_layer()
+            async_to_sync(channel_layer.group_send)(
+                f"notifications_{notification.sender.username}",
+                {"type": "trigger_sidebar_refresh"},
+            )
+        return None
+
+
+NOTIFICATION_STRATEGIES = {
+    "friend_request": FriendRequestStrategy(),
+    "game_invite": GameInviteStrategy(),
+}

--- a/fulabra_app/views.py
+++ b/fulabra_app/views.py
@@ -10,6 +10,8 @@ from .utils import hx_redirect, invite_to_lobby, lobby_is_full, set_player_prese
 from .contexts import LobbyContext
 from .models import *
 
+from .services.notification_strategy import NOTIFICATION_STRATEGIES
+
 
 def index_view(request: HttpRequest):
     return render(request, "fulabra_app/index.html")
@@ -295,41 +297,14 @@ def notification_action_view(request: HttpRequest, notification_id: int):
         notification = get_object_or_404(Notification, id=notification_id, recipient=request.user)
         action = request.POST.get("action")
 
-        if notification.notification_type == "friend_request":
-            friend_request = FriendRequest.objects.filter(id=notification.target_id).first()
-            if friend_request:
-                if action == "accept":
-                    friend_request.status = "accepted"
-                    request.user.friends.add(friend_request.from_user)
-                    friend_request.from_user.friends.add(request.user)
-                elif action == "reject":
-                    friend_request.status = "rejected"
-                friend_request.save()
-        
-        elif notification.notification_type == "game_invite":
-            if action == "accept":
-                lobby = LobbyGroup.objects.filter(id=notification.target_id).first()
+        notification.is_read = True
+        notification.save()
 
-                notification.is_read = True
-                notification.save()
-                
-                if lobby:
-                    return hx_redirect("lobby_invite", kwargs={"lobby_code": lobby.code})
-                else:
-                    return HttpResponse("Lobby no longer exists", status=404)
-            elif action == "reject":
-                notification.is_read = True
-                notification.save()
-
-                # Se o convite foi recusado, libera o botão de volta pra enviar convite
-                from channels.layers import get_channel_layer
-                from asgiref.sync import async_to_sync
-                
-                channel_layer = get_channel_layer()
-                async_to_sync(channel_layer.group_send)(
-                    f"notifications_{notification.sender.username}",
-                    {"type": "trigger_sidebar_refresh"}
-                )
+        strategy = NOTIFICATION_STRATEGIES.get(notification.notification_type)
+        if strategy:
+            early_response = strategy.handle(request, notification, action)
+            if early_response is not None:
+                return early_response
         
         notification.is_read = True
         notification.save()

--- a/fulabra_app/views.py
+++ b/fulabra_app/views.py
@@ -10,7 +10,7 @@ from .utils import hx_redirect, invite_to_lobby, lobby_is_full, set_player_prese
 from .contexts import LobbyContext
 from .models import *
 
-from .services.notification_strategy import NOTIFICATION_STRATEGIES
+from .services.notification_strategy import NotificationContext
 
 
 def index_view(request: HttpRequest):
@@ -297,17 +297,11 @@ def notification_action_view(request: HttpRequest, notification_id: int):
         notification = get_object_or_404(Notification, id=notification_id, recipient=request.user)
         action = request.POST.get("action")
 
-        notification.is_read = True
-        notification.save()
+        context = NotificationContext(notification)
+        early_response = context.execute(request, action)
 
-        strategy = NOTIFICATION_STRATEGIES.get(notification.notification_type)
-        if strategy:
-            early_response = strategy.handle(request, notification, action)
-            if early_response is not None:
-                return early_response
-        
-        notification.is_read = True
-        notification.save()
+        if early_response is not None:
+            return early_response
 
         # Se o inbox zerou as notificações
         unread_count = request.user.notifications.filter(is_read=False).count()


### PR DESCRIPTION
## What does this PR solve?
This PR implements the refactor request of **[Refactor] Change the Notification logic to Strategy Pattern** feature described in issue #50.

This PR upgrades the initial notification action routing into a classical, production-grade implementation of the **Strategy Design Pattern** (aligned with GoF standards). 

By introducing an explicit `NotificationContext` and leveraging Python's Abstract Base Classes (`abc`), we have completely decoupled the Django views from concrete business rules, eliminated database update duplications, and established a highly extensible architecture for future notification types.

## What was done?
- **Formalized Abstract Interface:** Transformed `NotificationStrategy` into a strict interface utilizing Python's `abc.ABC` and `@abstractmethod` decorators to enforce design contracts.
- **Introduced NotificationContext:** Created a dedicated `NotificationContext` class to act as the sole mediator between the client (the View) and the strategies. 
- **Centralized Lifecycle Hooks (DRY):** Moved the notification pre-processing logic (`is_read = True` and database `.save()`) into the `Context.execute()` method. This eliminated duplicate database operations across concrete strategy classes.
- **Hardened View Isolation:** Refactored `notification_action_view` to interact exclusively with the `NotificationContext`. The view no longer imports strategy dictionaries or knows anything about individual notification type behaviors.

## Acceptance Criteria
- [x] Notification interface strictly forces subclasses to implement the `handle` method via `abc`.
- [x] `NotificationContext` handles global states (marking as read and persistence) before delegation.
- [x] View is fully decoupled from individual strategy mappings.
- [x] Friend requests (accept/reject) and Game Invites (accept/reject with live WebSocket reloads) remain fully functional.

Closes #50 