### PR TITLE
Translated interface to Portuguese

### DIFF
--- a/fulabra_app/templates/fulabra_app/edit_profile.html
+++ b/fulabra_app/templates/fulabra_app/edit_profile.html
@@ -58,7 +58,7 @@
               </div>
 
               <div class="form-group">
-                <label for="id_nickname"><strong>Nickname:</strong></label>
+                <label for="id_nickname"><strong>Apelido:</strong></label>
                 {{ form.nickname }}
                 <small class="text-muted">Como você quer ser chamado nas partidas.</small>
               </div>

--- a/fulabra_app/templates/fulabra_app/friends_list.html
+++ b/fulabra_app/templates/fulabra_app/friends_list.html
@@ -2,14 +2,14 @@
 
 {% block body %}
 <div class="container py-4 max-w-md mx-auto" style="max-width: 600px;">
-  <h2 class="fw-bold mb-4 d-flex align-items-center gap-2"> Friends</h2>
+  <h2 class="fw-bold mb-4 d-flex align-items-center gap-2"> Amizades</h2>
 
   <ul class="nav nav-pills nav-fill mb-4 bg-white shadow-sm p-1 rounded-pill" id="friendsTabs" role="tablist">
     <li class="nav-item" role="presentation">
-      <a class="nav-link active rounded-pill fw-bold" id="my-friends-tab" data-toggle="pill" href="#my-friends" role="tab">My Friends</a>
+      <a class="nav-link active rounded-pill fw-bold" id="my-friends-tab" data-toggle="pill" href="#my-friends" role="tab">Meus amigos</a>
     </li>
     <li class="nav-item" role="presentation">
-      <a class="nav-link rounded-pill fw-bold" id="find-users-tab" data-toggle="pill" href="#find-users" role="tab">Find Users</a>
+      <a class="nav-link rounded-pill fw-bold" id="find-users-tab" data-toggle="pill" href="#find-users" role="tab">Buscar Usuários</a>
     </li>
   </ul>
 
@@ -17,7 +17,7 @@
  
     <button class="btn btn-outline-primary rounded-pill btn-sm fw-bold mb-2" 
         onclick="navigator.clipboard.writeText('{{ request.scheme }}://{{ request.get_host }}{% url 'invite_link' request.user.username %}'); alert('Link copied!');">
-      <i class="bi bi-link-45deg"></i> Share Invite Link
+      <i class="bi bi-link-45deg"></i> Compartilhar link de convite
     </button>
  
     <div class="tab-pane fade show active" id="my-friends" role="tabpanel">
@@ -61,7 +61,7 @@
         {% empty %}
           <div class="text-center py-5 text-muted">
             <i class="bi bi-emoji-frown display-1 mb-3 d-block"></i>
-            <p class="fs-5 m-0">You don't have any friends yet.</p>
+            <p class="fs-5 m-0">Você não tem amizades ainda.</p>
           </div>
         {% endfor %}
       </div>
@@ -80,7 +80,7 @@
 
       <div id="search-results" class="d-flex flex-column gap-2">
         <div class="text-center py-5 text-muted small">
-          Start typing to find new players.
+          Digite para encontrar novos jogadores (mínimo 3 caracteres).
         </div>
       </div>
     </div>

--- a/fulabra_app/templates/fulabra_app/guest_form.html
+++ b/fulabra_app/templates/fulabra_app/guest_form.html
@@ -6,7 +6,7 @@
       <div class="col-12 col-md-8 col-lg-6">
         <div class="card border-0 rounded-4 shadow overflow-hidden">
           <div class="bg-primary text-center text-white mb-4 p-4">
-            <h3 class="fw-bold m-0">Play as a Guest</h3>
+            <h3 class="fw-bold m-0">Jogar como convidado</h3>
           </div>
           <div class="card-body p-4 p-sm-5">
             <form method="post" enctype="multipart/form-data" class="needs-validation">
@@ -31,7 +31,7 @@
               </div>
 
               <div class="mb-4">
-                <label class="form-label fw-semibold text-secondary small text-uppercase tracking-wider mb-3">Choose an Avatar Option</label>
+                <label class="form-label fw-semibold text-secondary small text-uppercase tracking-wider mb-3">Escolha um avatar</label>
 
                 <div class="row g-3 text-center align-items-center justify-content-start">
                   {% for preset in avatar_presets %}
@@ -49,9 +49,9 @@
           </div>
           <div class="card-footer bg-light border-0 py-3 text-center">
             <p class="mb-0 small text-muted fw-medium">
-              If you want to save your progrees or choose a custom avatar,
-              <a href="{% url 'login' %}" class="text-decoration-none text-primary fw-semibold ms-1">Log In here</a>
-              or <a href="{% url 'register' %}" class="text-decoration-none text-primary fw-semibold ms-1">Register</a>
+              Se você quiser salvar seu progresso ou escolher um avatar personalizado,
+              <a href="{% url 'login' %}" class="text-decoration-none text-primary fw-semibold ms-1">Faça login aqui</a>
+              ou <a href="{% url 'register' %}" class="text-decoration-none text-primary fw-semibold ms-1">Registre-se</a>
             </p>
           </div>
         </div>

--- a/fulabra_app/templates/fulabra_app/inbox.html
+++ b/fulabra_app/templates/fulabra_app/inbox.html
@@ -3,7 +3,7 @@
 {% block body %}
 <div class="container py-4 max-w-md mx-auto" style="max-width: 600px;">
   <h2 class="fw-bold mb-4 d-flex align-items-center gap-2">
-    Inbox
+    Caixa de Entrada
   </h2>
 
   <div id="inbox-list" class="d-flex flex-column gap-3">
@@ -15,9 +15,9 @@
             <span class="badge bg-warning mb-1 rounded-2 small">{{ note.get_notification_type_display }}</span>
             <p class="mb-0 fw-medium">
               {% if note.notification_type == 'friend_request' %}
-                <a href="{% url "profile" note.sender.username %}" class="text-decoration-none">{{ note.sender.username }}</a> sent you a friend request!
+                <a href="{% url "profile" note.sender.username %}" class="text-decoration-none">{{ note.sender.username }}</a> te enviou um pedido de amizade!
               {% elif note.notification_type == 'game_invite' %}
-                <a href="{% url "profile" note.sender.username %}" class="text-decoration-none">{{ note.sender.username }}</a> has invited you to their lobby!
+                <a href="{% url "profile" note.sender.username %}" class="text-decoration-none">{{ note.sender.username }}</a> te convidou para o lobby dele!
               {% endif %}
             </p>
             <small class="text-muted" style="font-size: 0.75rem;">{{ note.created_at|timesince }} ago</small>
@@ -29,7 +29,7 @@
                   hx-swap="outerHTML">
               {% csrf_token %}
               <input type="hidden" name="action" value="accept">
-              <button type="submit" class="btn btn-sm btn-success rounded-4 px-3 fw-bold">Accept</button>
+              <button type="submit" class="btn btn-sm btn-success rounded-4 px-3 fw-bold">Aceitar</button>
             </form>
 
             <form hx-post="{% url 'notification_action' note.id %}" 
@@ -37,7 +37,7 @@
                   hx-swap="outerHTML">
               {% csrf_token %}
               <input type="hidden" name="action" value="reject">
-              <button type="submit" class="btn btn-sm btn-outline-danger rounded-4 px-3 fw-bold">Decline</button>
+              <button type="submit" class="btn btn-sm btn-outline-danger rounded-4 px-3 fw-bold">Recusar</button>
             </form>
           </div>
 
@@ -46,8 +46,8 @@
     {% empty %}
       <div id="empty-inbox-msg" class="text-center py-5 text-muted">
         <i class="bi bi-envelope-open display-1 mb-3 d-block"></i>
-        <p class="fs-5 m-0">Your inbox is empty.</p>
-        <p class="small">You're all caught up!</p>
+        <p class="fs-5 m-0">Sua caixa de entrada está vazia.</p>
+        <p class="small">Você já está por dentro de tudo!</p>
       </div>
     {% endfor %}
   </div>

--- a/fulabra_app/templates/fulabra_app/index.html
+++ b/fulabra_app/templates/fulabra_app/index.html
@@ -2,21 +2,21 @@
 {% load static %}
 
 {% block body %}
-  <h2>Enter in a Lobby</h2>
+  <h2>Entre num Lobby</h2>
   <form hx-post="{% url 'handle_lobby' %}" hx-swap="none">
     {% csrf_token %}
     <div class="form-group">
       <input id="lobby_code" name="lobby_code" class="form-control" type="text" placeholder="code" />
     </div>
     <div class="form-group">
-      <button class="btn btn-primary" type="submit">Enter</button>
+      <button class="btn btn-primary" type="submit">Entrar</button>
     </div>
   </form>
 
   <form method="post" action="{% url 'create_lobby' %}" >
     {% csrf_token %}
     <div class="form-group">
-      <button class="btn btn-primary" type="submit">Create Lobby</button>
+      <button class="btn btn-primary" type="submit">Crirar Lobby</button>
     </div>
   </form>
   {% include 'fulabra_app/partials/error_message.html' %}

--- a/fulabra_app/templates/fulabra_app/layout.html
+++ b/fulabra_app/templates/fulabra_app/layout.html
@@ -54,14 +54,14 @@
             </li>
 
             <li class="nav-item">
-              <a class="nav-link" href="{% url 'logout' %}">Log Out</a>
+              <a class="nav-link" href="{% url 'logout' %}">Sair</a>
             </li>
           {% else %}
             <li class="nav-item">
               <a class="nav-link" href="{% url 'login' %}">Log In</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="{% url 'register' %}">Register</a>
+              <a class="nav-link" href="{% url 'register' %}">Registre-se</a>
             </li>
           {% endif %}
         </ul>

--- a/fulabra_app/templates/fulabra_app/lobby.html
+++ b/fulabra_app/templates/fulabra_app/lobby.html
@@ -16,16 +16,16 @@
             <div id="game-container" class="card border-0 rounded-4 shadow-lg h-100 p-4">
               <div class="d-flex justify-content-between align-items-center mb-4 border-bottom border-secondary pb-3">
                 <div>
-                  <span class="text-uppercase tracking-wider text-muted small fw-bold">Private Match</span>
+                  <span class="text-uppercase tracking-wider text-muted small fw-bold">Partida Privada</span>
                   <h2 class="text-dark fw-extrabold m-0">Lobby #{{ context.current_lobby.code }}</h2>
                 </div>
 
-                <button id="btn-invite" class="btn btn-outline-secondary rounded-pill px-4 btn-sm fw-bold transition-all" data-invite-link="{{ context.invite }}">Copy Invite Link</button>
+                <button id="btn-invite" class="btn btn-outline-secondary rounded-pill px-4 btn-sm fw-bold transition-all" data-invite-link="{{ context.invite }}">Copiar link de convite</button>
               </div>
 
               <div id="category-container">
                 {% if user.player == context.current_lobby.leader %}
-                  <label for="category">Category:</label>
+                  <label for="category">Categoria:</label>
                   <select id="category" name="category" ws-send>
                     {% for c in context.categories %}
                       {% if c == context.current_category %}
@@ -47,7 +47,7 @@
               </div>
 
               <div class="mt-4 pt-3 border-top border-secondary d-flex justify-content-start">
-                <a href="{% url 'index' %}" class="btn btn-outline-danger px-4 rounded-pill fw-bold"><i class="bi bi-box-arrow-left"></i> Leave Lobby</a>
+                <a href="{% url 'index' %}" class="btn btn-outline-danger px-4 rounded-pill fw-bold"><i class="bi bi-box-arrow-left"></i> Sair do Lobby</a>
               </div>
             </div>
           </div>
@@ -101,7 +101,7 @@
       const originalText = inviteBtn.innerHTML
       inviteBtn.addEventListener('click', function () {
         navigator.clipboard.writeText(inviteBtn.dataset.inviteLink).then(function () {
-          inviteBtn.innerHTML = '<i class="bi bi-check-lg"></i> Copied! ✓'
+          inviteBtn.innerHTML = '<i class="bi bi-check-lg"></i> Copiado! ✓'
           inviteBtn.classList.replace('btn-outline-info', 'btn-success')
           setTimeout(function () {
             inviteBtn.innerHTML = originalText

--- a/fulabra_app/templates/fulabra_app/login.html
+++ b/fulabra_app/templates/fulabra_app/login.html
@@ -6,7 +6,7 @@
       <div class="col-12 col-md-8 col-lg-5">
         <div class="card shadow border-0 rounded-4 overflow-hidden">
           <div class="bg-primary p-4 text-center text-white">
-            <h3 class="fw-bold mb-0">Welcome Back</h3>
+            <h3 class="fw-bold mb-0">Bem-vindo novamente!</h3>
           </div>
 
           <div class="card-body p-4 p-sm-5" id="login-card-body">
@@ -15,11 +15,11 @@
 
           <div class="card-footer bg-light border-0 py-3 text-center">
             <p class="mb-0 small text-muted fw-medium">
-              <a href="{% url 'password_reset' %}" class="text-decoration-none text-primary fw-semibold ms-1">Forget Password?</a>
+              <a href="{% url 'password_reset' %}" class="text-decoration-none text-primary fw-semibold ms-1">Esqueceu a senha?</a>
             </p>
             <p class="mb-0 small text-muted fw-medium">
-              Don't have an account?  
-              <a href="{% url 'register' %}{% if next_url %}?next={{ next_url }}{% endif %}" class="text-decoration-none text-primary fw-semibold ms-1">Register here</a>
+              Ainda não tem uma conta?
+              <a href="{% url 'register' %}{% if next_url %}?next={{ next_url }}{% endif %}" class="text-decoration-none text-primary fw-semibold ms-1">Registre-se aqui</a>
             </p>
           </div>
         </div>

--- a/fulabra_app/templates/fulabra_app/partials/cancel_button.html
+++ b/fulabra_app/templates/fulabra_app/partials/cancel_button.html
@@ -3,6 +3,6 @@
         class="btn btn-outline-danger rounded-pill px-4 fw-bold shadow-sm"
         hx-vals='{"action": "cancel_match"}'
         ws-send>
-        <i class="bi bi-x-circle-fill me-2"></i> CANCEL MATCH
+        <i class="bi bi-x-circle-fill me-2"></i> CANCELAR
       </button>
 </div>

--- a/fulabra_app/templates/fulabra_app/partials/category.html
+++ b/fulabra_app/templates/fulabra_app/partials/category.html
@@ -1,1 +1,1 @@
-<span id="category-span" hx-swap-oob="innerHTML">Category: {{ context.current_category }}</span>
+<span id="category-span" hx-swap-oob="innerHTML">Categoria: {{ context.current_category }}</span>

--- a/fulabra_app/templates/fulabra_app/partials/game_frame.html
+++ b/fulabra_app/templates/fulabra_app/partials/game_frame.html
@@ -2,7 +2,7 @@
 <div id="game-container" hx-swap-oob="innerHTML">
   <div class="d-flex flex-column align-items-center text-center justify-content-between py-1 position-relative">
     {% if context.round.round_number >= 2 %}
-      <p>These were the words from the last round...</p>
+      <p>Esssa foram as palavras da última rodada...</p>
       <div class="row row-cols-3 justify-content-center g-3 w-100 max-width-md my-3">
         {% for res in context.round_result_list %}
           <div class="col">
@@ -17,7 +17,7 @@
         {% endfor %}
       </div>
     {% else %}
-      <p>Choose a random first word to begin the game!</p>
+      <p>Escolha uma palavra aleatória para começar!</p>
     {% endif %}
 
     <div class="w-100 mb-3">
@@ -28,7 +28,7 @@
             <span class="fw-bold text-dark fs-5">#{{ context.lobby.code }}</span>
           </div>
           <div style="margin-left: 20px;">
-            <span class="text-uppercase tracking-wider text-muted small d-block fw-semibold" style="font-size: 0.75rem;">Category</span>
+            <span class="text-uppercase tracking-wider text-muted small d-block fw-semibold" style="font-size: 0.75rem;">Categoria</span>
             <span class="fw-bold text-dark fs-5">{{ context.game.category }}</span>
           </div>
         </div>

--- a/fulabra_app/templates/fulabra_app/partials/notification_card.html
+++ b/fulabra_app/templates/fulabra_app/partials/notification_card.html
@@ -5,9 +5,9 @@
         <span class="badge bg-warning mb-1 rounded-2 small">{{ note.get_notification_type_display }}</span>
         <p class="mb-0 fw-medium">
           {% if note.notification_type == 'friend_request' %}
-            <a href="{% url "profile" note.sender.username %}" class="text-decoration-none">{{ note.sender.username }}</a> sent you a friend request!
+            <a href="{% url "profile" note.sender.username %}" class="text-decoration-none">{{ note.sender.username }}</a> te enviou um pedido de amizade!
           {% elif note.notification_type == 'game_invite' %}
-            <a href="{% url "profile" note.sender.username %}" class="text-decoration-none">{{ note.sender.username }}</a> has invited you to their lobby!
+            <a href="{% url "profile" note.sender.username %}" class="text-decoration-none">{{ note.sender.username }}</a> te convidou para o lobby dele!
           {% endif %}
         </p>
         <small class="text-muted" style="font-size: 0.75rem;">{{ note.created_at|timesince }} ago</small>
@@ -19,7 +19,7 @@
               hx-swap="outerHTML">
           {% csrf_token %}
           <input type="hidden" name="action" value="accept">
-          <button type="submit" class="btn btn-sm btn-success rounded-4 px-3 fw-bold">Accept</button>
+          <button type="submit" class="btn btn-sm btn-success rounded-4 px-3 fw-bold">Aceitar</button>
         </form>
 
         <form hx-post="{% url 'notification_action' note.id %}" 
@@ -27,7 +27,7 @@
               hx-swap="outerHTML">
           {% csrf_token %}
           <input type="hidden" name="action" value="reject">
-          <button type="submit" class="btn btn-sm btn-outline-danger rounded-4 px-3 fw-bold">Decline</button>
+          <button type="submit" class="btn btn-sm btn-outline-danger rounded-4 px-3 fw-bold">Recusar</button>
         </form>
       </div>
     </div>

--- a/fulabra_app/templates/fulabra_app/partials/online_friends_list.html
+++ b/fulabra_app/templates/fulabra_app/partials/online_friends_list.html
@@ -3,8 +3,8 @@
   hx-trigger="refreshSidebar from:body"
   hx-swap="outerHTML">
   <div class="card border-0 rounded-4 shadow-lg h-100 p-4">
-    <h4 class="fw-bold mb-3 d-flex align-items-center gap-2"><span class="pulse-indicator bg-success me-2" role="status"></span>&nbsp;Online Friends</h4>
-    <p class="text-muted small mb-4">Invite your squad to fill the missing slots.</p>
+    <h4 class="fw-bold mb-3 d-flex align-items-center gap-2"><span class="pulse-indicator bg-success me-2" role="status"></span>&nbsp;Amigos Online</h4>
+    <p class="text-muted small mb-4">Convide amigos para preenchar as vagas restantes.</p>
 
     <div class="friend-sidebar-list d-flex flex-column gap-2 overflow-auto style-scrollbar" style="max-height: 400px;">
       {% for f in context.online_friends %}
@@ -19,9 +19,9 @@
           {% if f.player in context.lobby_players %}
             <button class="btn btn-sm btn-secondary rounded-pill px-3 fw-bold" disabled>In Lobby</button>
           {% elif context.lobby_players|length >= 3 %}
-            <button class="btn btn-sm btn-dark rounded-pill px-3 fw-bold" disabled><i class="bi bi-slash-circle me-1"></i> Lobby Full</button>
+            <button class="btn btn-sm btn-dark rounded-pill px-3 fw-bold" disabled><i class="bi bi-slash-circle me-1"></i> Lobby cheio</button>
           {% elif f.id in context.pending_invite_user_ids %}
-            <button class="btn btn-sm btn-success rounded-pill px-3 fw-bold" disabled><i class="bi bi-check-lg me-1"></i> Sent!</button>
+            <button class="btn btn-sm btn-success rounded-pill px-3 fw-bold" disabled><i class="bi bi-check-lg me-1"></i> Enviado!</button>
           {% else %}
             <button type="button" 
                     class="btn btn-sm btn-primary rounded-pill px-3 fw-bold invite-btn"
@@ -35,7 +35,7 @@
       {% empty %}
         <div class="text-center py-5 text-muted">
           <i class="bi bi-people mb-2 display-6 d-block"></i>
-          <p class="small m-0">No friends online right now.</p>
+          <p class="small m-0">Nenhum amigo online agora.</p>
         </div>
       {% endfor %}
     </div>

--- a/fulabra_app/templates/fulabra_app/partials/player_list.html
+++ b/fulabra_app/templates/fulabra_app/partials/player_list.html
@@ -34,18 +34,18 @@
         class="btn btn-primary rounded-pill fw-extrabold"
         hx-vals='{"action":"start_game"}'
         ws-send>
-          START MATCH
+          Começar
         </button>
       {% else %}
         <div class="text-center">
           <span class="spinner-grow spinner-grow-sm text-primary me-2" role="status"></span>
-          Waiting for Host to start the game...
+          Agurdando o host para começar o jogo...
         </div>
       {% endif %}
     </div>
   {% else %}
     <div class="text-secondary small mx-auto py-2 text-center">
-      <i class="bi bi-exclamation-triangle-fill"></i> Waiting for exactly 3 players to lock in...
+      <i class="bi bi-exclamation-triangle-fill"></i> Aguardando chegar 3 jogadores...
     </div>
   {% endif %}
 </div>

--- a/fulabra_app/templates/fulabra_app/partials/players_frame.html
+++ b/fulabra_app/templates/fulabra_app/partials/players_frame.html
@@ -18,7 +18,7 @@
     </div>
   {% empty %}
     <div class="text-center py-3">
-      <small class="text-muted">Waiting for players...</small>
+      <small class="text-muted">Aguardado por jogadores...</small>
     </div>
   {% endfor %}
 </div>

--- a/fulabra_app/templates/fulabra_app/partials/register_form_inner.html
+++ b/fulabra_app/templates/fulabra_app/partials/register_form_inner.html
@@ -7,7 +7,7 @@
 
   {% if form.errors and not form.non_field_errors %}
     <div class="alert alert-danger border-0 rounded-3 small mb-3">
-      <i class="bi bi-exclamation-triangle-fill me-2"></i> Please correct the highlighted fields below.
+      <i class="bi bi-exclamation-triangle-fill me-2"></i> Por favor, corriga os campos destacados.
     </div>
   {% endif %}
 
@@ -41,6 +41,6 @@
   {% endfor %}
 
   <div class="d-grid mt-4">
-    <button type="submit" class="btn btn-primary rounded-3 fw-semibold fs-6 py-2.5 shadow-sm">Register Account</button>
+    <button type="submit" class="btn btn-primary rounded-3 fw-semibold fs-6 py-2.5 shadow-sm">Registrar-se</button>
   </div>
 </form>

--- a/fulabra_app/templates/fulabra_app/partials/return_to_lobby.html
+++ b/fulabra_app/templates/fulabra_app/partials/return_to_lobby.html
@@ -1,3 +1,3 @@
 <a id="return_lobby_link" href=" {% url 'lobby_invite' context.lobby_code %}" hx-swap-oob="true">
-    <button type="button" class="btn btn-primary rounded-pill fw-extrabold">Return to Lobby</button>
+    <button type="button" class="btn btn-primary rounded-pill fw-extrabold">Voltar ao Lobby</button>
 </a>

--- a/fulabra_app/templates/fulabra_app/partials/round_result.html
+++ b/fulabra_app/templates/fulabra_app/partials/round_result.html
@@ -2,16 +2,16 @@
   {% for res in context.round_result_list %}
     <div>
       {% if res.status == 'earns' %}
-        <strong>{{ res.player.nickname }}</strong> sent <span class="text-success">{{ res.word }}</span>, current pnts: {{ res.score }} <small class="text-success">(+1)</small>
+        <strong>{{ res.player.nickname }}</strong> enviou <span class="text-success">{{ res.word }}</span>, pnts atual: {{ res.score }} <small class="text-success">(+1)</small>
       {% elif res.status == 'loses' %}
-        <strong>{{ res.player.nickname }}</strong> sent <span class="text-danger">{{ res.word }}</span>, current pnts: {{ res.score }} <small class="text-danger">(-1)</small>
+        <strong>{{ res.player.nickname }}</strong> enviou <span class="text-danger">{{ res.word }}</span>, pnts atual: {{ res.score }} <small class="text-danger">(-1)</small>
       {% else %}
-        <strong>{{ res.player.nickname }}</strong> sent <span>{{ res.word|default:'-' }}</span>, current pnts: {{ res.score }}
+        <strong>{{ res.player.nickname }}</strong> enviou <span>{{ res.word|default:'-' }}</span>, pnts atual: {{ res.score }}
       {% endif %}
     </div>
     <div>
       {% if res.score >= 3 %}
-        <strong class="text-warning">{{ res.player.nickname }}</strong> won!
+        <strong class="text-warning">{{ res.player.nickname }}</strong> venceu!
       {% endif %}
     </div>
   {% endfor %}

--- a/fulabra_app/templates/fulabra_app/partials/search_results.html
+++ b/fulabra_app/templates/fulabra_app/partials/search_results.html
@@ -13,7 +13,7 @@
       <form hx-post="{% url 'add_friend' result.player.id %}" hx-swap="outerHTML">
         {% csrf_token %}
         <button type="submit" class="btn btn-sm btn-primary rounded-pill px-3 fw-bold">
-          <i class="bi bi-person-plus-fill"></i> Add
+          <i class="bi bi-person-plus-fill"></i> Adicioanr
         </button>
       </form>
       
@@ -22,6 +22,6 @@
 {% empty %}
   <div class="text-center py-4 text-muted">
     <i class="bi bi-search display-4 mb-2 d-block"></i>
-    <p class="m-0">No players found.</p>
+    <p class="m-0">Nenhum jogador encontrado.</p>
   </div>
 {% endfor %}

--- a/fulabra_app/templates/fulabra_app/partials/word_form.html
+++ b/fulabra_app/templates/fulabra_app/partials/word_form.html
@@ -4,9 +4,9 @@
     {{ context.form.action }}
     {{ context.form.word }}
     {% if context.submitted %}
-      <button type="submit" class="btn btn-lg btn-danger px-4 fw-bold" style="min-width: 140px;">CANCEL</button>
+      <button type="submit" class="btn btn-lg btn-danger px-4 fw-bold" style="min-width: 140px;">Cancelar</button>
     {% else %}
-      <button type="submit" class="btn btn-lg btn-success px-4 fw-bold" style="min-width: 140px;">Confirm</button>
+      <button type="submit" class="btn btn-lg btn-success px-4 fw-bold" style="min-width: 140px;">Confirmar</button>
     {% endif %}
   </div>
   <div class="d-flex justify-content-between align-items-center w-100">

--- a/fulabra_app/templates/fulabra_app/register.html
+++ b/fulabra_app/templates/fulabra_app/register.html
@@ -7,7 +7,7 @@
       <div class="col-12 col-md-8 col-lg-6">
         <div class="card shadow border-0 rounded-4 overflow-hidden">
           <div class="bg-primary p-4 text-center text-white">
-            <h3 class="fw-bold mb-0">Create Account</h3>
+            <h3 class="fw-bold mb-0">Criar Conta</h3>
           </div>
 
           <div class="card-body p-4 p-sm-5" id="register-card-body">
@@ -16,8 +16,8 @@
 
           <div class="card-footer bg-light border-0 py-3 text-center">
             <p class="mb-0 small text-muted fw-medium">
-              Already have an account?
-              <a href="{% url 'login' %}" class="text-decoration-none text-primary fw-semibold ms-1">Log In here</a>
+              Já tem uma conta?
+              <a href="{% url 'login' %}" class="text-decoration-none text-primary fw-semibold ms-1">Faça login aqui</a>
             </p>
           </div>
         </div>

--- a/fulabra_app/templates/registration/password_reset_complete.html
+++ b/fulabra_app/templates/registration/password_reset_complete.html
@@ -9,12 +9,12 @@
             <i class="bi bi-check-circle-fill"></i>
           </div>
 
-          <h3 class="fw-bold text-dark mb-2">Password Reset Complete!</h3>
+          <h3 class="fw-bold text-dark mb-2">Redefinição de senha concluída!</h3>
 
-          <p class="text-muted mb-4 mx-auto" style="max-width: 360px;">Your new security credentials have been successfully updated. You can now securely sign back into the match.</p>
+          <p class="text-muted mb-4 mx-auto" style="max-width: 360px;">Suas novas credenciais de segurança foram atualizadas com sucesso. Agora você pode acessar a partida com segurança.</p>
 
           <div class="d-grid col-sm-8 mx-auto">
-            <a href="{% url 'login' %}" class="btn btn-success btn-lg rounded-3 fw-semibold fs-6 py-2.5 shadow-sm"><i class="bi bi-box-arrow-in-right me-2"></i> Log In Now</a>
+            <a href="{% url 'login' %}" class="btn btn-success btn-lg rounded-3 fw-semibold fs-6 py-2.5 shadow-sm"><i class="bi bi-box-arrow-in-right me-2"></i> Faça login agora</a>
           </div>
         </div>
       </div>

--- a/fulabra_app/templates/registration/password_reset_confirm.html
+++ b/fulabra_app/templates/registration/password_reset_confirm.html
@@ -51,12 +51,12 @@
             <div class="text-danger display-1 mb-3">
               <i class="bi bi-exclamation-octagon-fill"></i>
             </div>
-            <h3 class="fw-bold text-dark mb-2">Link Expired or Invalid</h3>
-            <p class="text-muted mb-4 mx-auto" style="max-width: 400px;">The password reset link has already been used, was altered, or has expired for security reasons.</p>
+            <h3 class="fw-bold text-dark mb-2">Link expirado ou inválido</h3>
+            <p class="text-muted mb-4 mx-auto" style="max-width: 400px;">O link para redefinição de senha já foi usado, foi alterado ou expirou por motivos de segurança.</p>
 
             <div class="d-grid gap-2 col-sm-8 mx-auto">
-              <a href="{% url 'password_reset' %}" class="btn btn-outline-primary rounded-3 fw-semibold py-2">Request New Reset Link</a>
-              <a href="{% url 'login' %}" class="btn btn-link text-decoration-none text-muted small">Back to sign in</a>
+              <a href="{% url 'password_reset' %}" class="btn btn-outline-primary rounded-3 fw-semibold py-2">Solicitar novo link de redefinição</a>
+              <a href="{% url 'login' %}" class="btn btn-link text-decoration-none text-muted small">Voltar para tela de login</a>
             </div>
           </div>
         {% endif %}

--- a/fulabra_app/templates/registration/password_reset_done.html
+++ b/fulabra_app/templates/registration/password_reset_done.html
@@ -6,8 +6,8 @@
     <div class="text-success fs-1 mb-3">
       <i class="bi bi-check-circle-fill"></i>
     </div>
-    <h2 class="fw-bold mb-3">Email sent!</h2>
-    <p class="text-muted">We've emailed you instructions for setting your password. You should receive it shortly.</p>
+    <h2 class="fw-bold mb-3">Email enviado!</h2>
+    <p class="text-muted">Enviamos por e-mail as instruções para definir sua senha. Você deverá recebê-las em breve.</p>
   </div>
 </div>
 {% endblock %}

--- a/fulabra_app/templates/registration/password_reset_form.html
+++ b/fulabra_app/templates/registration/password_reset_form.html
@@ -6,12 +6,12 @@
       <div class="col-12 col-md-8 col-lg-6">
         <div class="card shadow border-0 rounded-4 overflow-hidden">
           <div class="bg-primary p-4 text-center text-white">
-            <h3 class="fw-bold mb-0">Account Recovery</h3>
+            <h3 class="fw-bold mb-0">Recuperação de conta</h3>
           </div>
 
           <div class="card-body p-4 p-sm-5">
-            <h4 class="text-dark fw-semibold mb-2">Forgot your password?</h4>
-            <p class="text-muted small mb-4">Enter your registered email address below, and we will email you instructions to securely set a new one.</p>
+            <h4 class="text-dark fw-semibold mb-2">Esqueceu sua senha?</h4>
+            <p class="text-muted small mb-4">Insira seu endereço de e-mail cadastrado abaixo e enviaremos instruções por e-mail para que você possa configurar um novo endereço com segurança.</p>
 
             <form method="post" novalidate>
               {% csrf_token %}
@@ -19,7 +19,7 @@
               {% if form.errors %}
                 <div class="alert alert-danger border-0 rounded-3 small mb-4" role="alert">
                   <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                  Please correct the errors below.
+                  Por favor, corrija os erros abaixo.
                 </div>
               {% endif %}
 
@@ -36,13 +36,13 @@
               {% endfor %}
 
               <div class="d-grid mt-2">
-                <button type="submit" class="btn btn-primary rounded-3 fw-semibold fs-6 py-2.5 shadow-sm transition-all"><i class="bi bi-envelope-fill me-2"></i> Send Reset Link</button>
+                <button type="submit" class="btn btn-primary rounded-3 fw-semibold fs-6 py-2.5 shadow-sm transition-all"><i class="bi bi-envelope-fill me-2"></i> Enviar link de redefinição</button>
               </div>
             </form>
           </div>
 
           <div class="card-footer bg-light border-0 py-3 text-center">
-            <a href="{% url 'login' %}" class="text-decoration-none small fw-medium text-primary"><i class="bi bi-arrow-left me-1"></i> Back to sign in</a>
+            <a href="{% url 'login' %}" class="text-decoration-none small fw-medium text-primary"><i class="bi bi-arrow-left me-1"></i> Voltar para tela de login</a>
           </div>
         </div>
       </div>

--- a/fulabra_app/tests.py
+++ b/fulabra_app/tests.py
@@ -30,7 +30,10 @@ def make_category_with_words(*labels) -> Category:
 
 class ScoringTest(TestCase):
     """
-    Rule: if exactly 2 players submit the same word, both earn +1 point.
+    Rules:
+        - if no player submits the same word, there will be no scoring.
+        - if exactly 2 players submit the same word, both earn +1 point.
+        - if 3 players submit the same word, they lose 1 point.
     """
 
     def setUp(self):
@@ -90,7 +93,7 @@ class ScoringTest(TestCase):
             key=lambda r: r.player.nickname,
         )
 
-        self.assertEqual(results, expected, "no player should earns or loses a point")
+        self.assertEqual(results, expected, "no player should earn or lose a point")
 
     def test_two_matching_perform_scoring(self):
         # p1 and p2 submit "apple"; p3 submits "banana"

--- a/fulabra_app/utils.py
+++ b/fulabra_app/utils.py
@@ -36,8 +36,8 @@ def lobby_is_full(lobby: LobbyGroup, player: Player = None) -> bool:
     return lobby.lobby_memberships.count() >= 3
 
 
-def get_last_game_round(game) -> GameRound:
-    GameRound.objects.filter(game=game).order_by("-round_number").first()
+def get_last_game_round(game: Game) -> GameRound:
+    return GameRound.objects.filter(game=game).order_by("-round_number").first()
 
 
 def perform_scoring(


### PR DESCRIPTION
## What does this PR solve?
This PR implements **[Refactor] Translate All Interface to Portuguese** described in issue #55 

Translating the application's user interface from English to Brazilian Portuguese to provide a more accessible and native experience for local players.

It also includes a small bug fix where a function was missing a return statement, ensuring the expected behavior during execution.

## What was done?
- **UI Localization:** Translated user-facing interface elements, game descriptions, buttons, messages, and other interactive text from English to Brazilian Portuguese (PT-BR).
- **Bug Fix:** Added a missing `return` statement to the funciton `get_last_game_round` to restore the expected application behavior.
- **General Cleanup:** Applied minor text and interface adjustments to maintain consistency throughout the application.

## Acceptance Criteria
- [x] **Interface Localization:** All user-facing interface elements are displayed in Brazilian Portuguese (PT-BR).

Closes #55 